### PR TITLE
Update UAAL example to support  Gradle 8 in 2023.3.0b7+

### DIFF
--- a/NativeAndroidApp/app/build.gradle
+++ b/NativeAndroidApp/app/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
 
 android {
+    namespace "com.unity.mynativeapp"
     compileSdkVersion 33
 
     defaultConfig {

--- a/NativeAndroidApp/app/src/main/java/com/unity/mynativeapp/MainActivity.java
+++ b/NativeAndroidApp/app/src/main/java/com/unity/mynativeapp/MainActivity.java
@@ -73,23 +73,20 @@ public class MainActivity extends AppCompatActivity {
         isGameActivity = !(v.getId() == R.id.show_unity_button);
         disableShowUnityButtons();
 
-        Intent intent;
-        switch (v.getId()) {
-            case R.id.show_unity_button:
-                intent = new Intent(this, getMainUnityActivityClass());
-                break;
-
-            case R.id.show_unity_game_button:
-                intent = new Intent(this, getMainUnityGameActivityClass());
-                break;
-
-            default:
-                return;
+        int id = v.getId();
+        if (id == R.id.show_unity_button) {
+            startUnityWithClass(getMainUnityActivityClass());
+        } else if (id == R.id.show_unity_game_button) {
+            startUnityWithClass(getMainUnityGameActivityClass());
         }
+    }
+
+    private void startUnityWithClass(Class klass)
+    {
+        Intent intent = new Intent(this, klass);
         intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
         startActivityForResult(intent, 1);
     }
-
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/docs/android.md
+++ b/docs/android.md
@@ -2,7 +2,7 @@
 This document explains how to include Unity as a Library into standard Android application through Activity. You can read more about [Unity as a Library](https://docs.unity3d.com/2019.3/Documentation/Manual/UnityasaLibrary.html).
 
 **Requirements:**
-- Android Studio Bumblebee (2021.1.1) or later
+- Android Studio Hedgehog (2023.1.1) or later
 - Unity version 2023.1.7f1, 2023.2.0b3 or later
 
 [Note] For Unity versions from 2019.3.0b4 to 2022.2.0a17 use [19LTS-21LTS branch](https://github.com/Unity-Technologies/uaal-example/tree/uaal-example/19LTS-21LTS). For Unity versions from 2022.2.0a17 to 2023.1.0a16 use [22LTS branch](https://github.com/Unity-Technologies/uaal-example/tree/uaal-example/22LTS).


### PR DESCRIPTION
## Purpose of this PR

This PR fixes compatibility with Unity 2023.3.0b7+ that ships with Gradle 8 and Android SDK 34. 

 - Manual testing of demo project in both Activity and GameActivity

### Comments to reviewers
The changes introduced by this PR are backwards compatible, meaning we don't need to create a new 23LTS branch to just support `2023.3.0b7+`.