### PR TITLE
Update Gradle to 7.5.1 (from 7.2) and AGP to 7.4.2 (from 7.1.2)

### DIFF
--- a/NativeAndroidApp/app/build.gradle
+++ b/NativeAndroidApp/app/build.gradle
@@ -12,12 +12,12 @@ dependencies {
 
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.unity.mynativeapp"
-        minSdkVersion 22
-        targetSdkVersion 31
+        minSdkVersion 23
+        targetSdkVersion 34
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a"
         }

--- a/NativeAndroidApp/build.gradle
+++ b/NativeAndroidApp/build.gradle
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
-    id 'com.android.library' version '7.1.2' apply false
+    id 'com.android.application' version '7.4.2' apply false
+    id 'com.android.library' version '7.4.2' apply false
 }
 
 task clean(type: Delete) {

--- a/NativeAndroidApp/gradle/wrapper/gradle-wrapper.properties
+++ b/NativeAndroidApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip

--- a/UnityProject/ProjectSettings/ProjectVersion.txt
+++ b/UnityProject/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2022.2.0b1
-m_EditorVersionWithRevision: 2022.2.0b1 (d791230a58d5)
+m_EditorVersion: 2022.3.38f1
+m_EditorVersionWithRevision: 2022.3.38f1 (7dafd5ffa44e)

--- a/docs/android.md
+++ b/docs/android.md
@@ -2,7 +2,7 @@
 This document explains how to include Unity as a Library into standard Android application through Activity. You can read more about [Unity as a Library](https://docs.unity3d.com/2019.3/Documentation/Manual/UnityasaLibrary.html).
 
 **Requirements:**
-- Android Studio Bumblebee (2021.1.1) or later
+- Android Studio Flamingo (2022.2.1) or later
 - Unity version 2022.2.0a18 or later
 [Note] For Unity versions from 2019.3.0b4 to 2022.2.0a17 use [this branch](https://github.com/Unity-Technologies/uaal-example/tree/uaal-example/19LTS-21LTS)
 


### PR DESCRIPTION
### Versions changing
 - AGP 7.4.2
 - Gradle 7.5.1
 - MinSdk 23 (22 is not supported anymore on 2022.3)
 - TargetSdk 34

### Testing
 - Tested locally following the steps in [android.md](https://github.com/Unity-Technologies/uaal-example/compare/uaal-example/22LTS...22LTS/update-gradle-agp-versions?expand=1#diff-75ef442502f500fc1f10e52492c7d74be563334c0fe49fd0b57af8776e3e8684). Tested on:
   -  S10+ (Android 11)
   -  Pixel 6a (Android 14)