### PR TITLE
[UUM-91484] UnityProject example: set theme for unity game activity to make it fullscreen on 6.1

### DIFF
--- a/UnityProject/Assets/Plugins/Android/MainApp.androidlib/src/main/AndroidManifest.xml
+++ b/UnityProject/Assets/Plugins/Android/MainApp.androidlib/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
             android:name=".MainUnityGameActivity"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"
             android:hardwareAccelerated="false"
+            android:theme="@style/AppTheme.NoActionBar"
             android:process=":Unity"
             android:screenOrientation="fullSensor"></activity>
     </application>

--- a/UnityProject/Assets/Plugins/Android/MainApp.androidlib/src/main/AndroidManifest.xml
+++ b/UnityProject/Assets/Plugins/Android/MainApp.androidlib/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
             android:name=".MainUnityActivity"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"
             android:hardwareAccelerated="false"
+            android:theme="@style/UnityThemeSelector"
             android:process=":Unity"
             android:screenOrientation="fullSensor"></activity>
 
@@ -30,7 +31,7 @@
             android:name=".MainUnityGameActivity"
             android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale|layoutDirection|density"
             android:hardwareAccelerated="false"
-            android:theme="@style/AppTheme.NoActionBar"
+            android:theme="@style/BaseUnityGameActivityTheme"
             android:process=":Unity"
             android:screenOrientation="fullSensor"></activity>
     </application>


### PR DESCRIPTION
# Description

**Jira link**: [UUM-91484](https://jira.unity3d.com/browse/UUM-91484)

On Unity 6.1, the UnityGameActivity example is broken because of the action bar, which shifts all of the input coordinates by the height of the bar. See attached video on [UUM-91483]( https://jira.unity3d.com/browse/UUM-91483)

This PR forces the UnityGameActivity from the example to be fullscreen even on Unity 6.1. This is done by using the NoActionBar theme in the Android manifest.