### PR TITLE
[Tests] Use `EditorApplication.sevenZipPath` for 6000.3+

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -1,5 +1,6 @@
 test_editors:
   - version: 6000.0
+  - version: 6000.3
 test_platforms:
   - name: win
     type: Unity::VM

--- a/UnityProject/Assets/Tests/Editor/Utilities.cs
+++ b/UnityProject/Assets/Tests/Editor/Utilities.cs
@@ -33,8 +33,12 @@ namespace UAAL.EditorTests
         }
 
 
+#if UNITY_6000_3_OR_NEWER
+        private static string SevenZipPath => EditorApplication.sevenZipPath;
+#else
         private static string SevenZipPath => Path.Combine(EditorApplication.applicationContentsPath, "Tools",
             Application.platform == RuntimePlatform.WindowsEditor ? "7z.exe" : "7za");
+#endif
 
         public static void BuildProject(string location, bool cleanDirectoryOrFile, out string warnings, bool openScene = false)
         {


### PR DESCRIPTION
As suggested by @davidrogers-unity, `EditorApplication.sevenZipPath` needs to be used in `6000.3` or newer. 

@todi1856  The `Unzip` function is unused, we could potentially delete it anyways since `SevenZipPath` is never used.